### PR TITLE
Fixed Outdated AppRouterInstance Path

### DIFF
--- a/components/booking/BookingForm.tsx
+++ b/components/booking/BookingForm.tsx
@@ -1,5 +1,5 @@
 import { Dialog } from "@headlessui/react"
-import type { AppRouterInstance } from "next/dist/shared/lib/app-router-context"
+import type { AppRouterInstance } from "next/dist/shared/lib/app-router-context.shared-runtime"
 import { useRouter } from "next/navigation"
 import type { Dispatch, FormEvent } from "react"
 


### PR DESCRIPTION
Was getting the below error:
Cannot find module 'next/dist/shared/lib/app-router-context' or its corresponding type declarations.

Fixed using Petr Gazarov's answer from this Stack Overflow post:
https://stackoverflow.com/questions/77116856/type-approuterinstance-is-not-assignable-to-type-nextrouter